### PR TITLE
Fix endTRY calculation

### DIFF
--- a/src/utils/calculateValues.js
+++ b/src/utils/calculateValues.js
@@ -16,7 +16,7 @@ export const calculateValues = (data, baseCurrency, startDate, endDate, amount) 
   const startTRY = baseCurrency === "TRY" ? amount : amount * startData.USDTRY;
   const endTRY = baseCurrency === "TRY"
     ? startTRY * (endData.TRYInflationIndex / startData.TRYInflationIndex)
-    : startTRY * (startData.USDTRY / endData.USDTRY);
+    : startTRY * (endData.USDTRY / startData.USDTRY);
 
   const startUSD = baseCurrency === "USD" ? amount : startTRY / startData.USDTRY;
   const endUSD = baseCurrency === "USD"


### PR DESCRIPTION
## Summary
- fix `endTRY` multiplier logic in calculateValues utility

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6873ab3475308327b6a9b94a7184573f