### PR TITLE
Fix yarn setup and docs for local development

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ cp src/output.json public/data/data.json
 
 Install dependencies and start the development server:
 
+The project uses Yarn 4. The included `.yarnrc.yml` configures Yarn to
+create a traditional `node_modules` folder. This is required so that
+`react-scripts` can find its ESLint configuration.
+
 ```bash
 yarn install
 yarn start


### PR DESCRIPTION
## Summary
- add `.yarnrc.yml` to force node_modules linking
- document this requirement in the README

## Testing
- `yarn test`
- `yarn start` *(logged output only)*

------
https://chatgpt.com/codex/tasks/task_e_6873d54ea8848327b94a1bbbd37c0b5f