### PR TITLE
Update graph to filter by date and show USD

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,6 @@ function App() {
   const [startDate, setStartDate] = useState("2022-01");
   const [endDate, setEndDate] = useState("2025-01");
   const [amount, setAmount] = useState(100); // Başlangıç miktarı
-  const [showGraph, setShowGraph] = useState(false);
 
   useEffect(() => {
     const loadData = async () => {
@@ -48,12 +47,7 @@ function App() {
         setStartDate={setStartDate}
         setEndDate={setEndDate}
       />
-      <div className="text-center my-3">
-        <button className="btn btn-primary" onClick={() => setShowGraph((prev) => !prev)}>
-          {showGraph ? "Grafiği Gizle" : "Grafiği Göster"}
-        </button>
-      </div>
-      {showGraph && <Graph data={data} />}
+      <Graph data={data} startDate={startDate} endDate={endDate} />
       <footer className="text-center mt-4">
         Mustafa Evleksiz tarafından geliştirilmiştir
       </footer>

--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -1,34 +1,64 @@
 // Version 2.2.1
 import React from "react";
 import { Line } from "react-chartjs-2";
-// Chart.js v3+ requires the chart components to be registered.
-// Importing "chart.js/auto" takes care of the registration automatically
-// so that the <Line /> component can render without errors.
 import "chart.js/auto";
 
-const Graph = ({ data }) => {
+// Graph shows inflation index and gold price for the selected date range.
+// Gold price is displayed both in TRY and USD. To make inflation values
+// visible alongside much larger price values, a secondary Y axis is used.
+const Graph = ({ data, startDate, endDate }) => {
+  if (!data || data.length === 0) return null;
+
+  const filtered = data.filter((item) => {
+    return (!startDate || item.Date >= startDate) &&
+           (!endDate || item.Date <= endDate);
+  });
+
   const chartData = {
-    labels: data.map((item) => item.Date),
+    labels: filtered.map((item) => item.Date),
     datasets: [
       {
         label: "Enflasyon Endeksi",
-        data: data.map((item) => item.InflationIndex),
+        data: filtered.map((item) => item.InflationIndex),
         borderColor: "rgba(75,192,192,1)",
         fill: false,
+        yAxisID: "yInflation",
       },
       {
         label: "Altın Fiyatı (Gram/TRY)",
-        data: data.map((item) => item.GoldPerGramTRY),
+        data: filtered.map((item) => item.GoldPerGramTRY),
         borderColor: "rgba(255,99,132,1)",
         fill: false,
+        yAxisID: "yPrice",
+      },
+      {
+        label: "Altın Fiyatı (Gram/USD)",
+        data: filtered.map((item) => item.GoldPerGramTRY / item.USDTRY),
+        borderColor: "rgba(54,162,235,1)",
+        fill: false,
+        yAxisID: "yPrice",
       },
     ],
+  };
+
+  const options = {
+    responsive: true,
+    scales: {
+      yInflation: {
+        position: "left",
+        ticks: { callback: (val) => val.toFixed(2) },
+      },
+      yPrice: {
+        position: "right",
+        grid: { drawOnChartArea: false },
+      },
+    },
   };
 
   return (
     <div>
       <h3>Enflasyon ve Altın Fiyatı</h3>
-      <Line data={chartData} />
+      <Line data={chartData} options={options} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- auto-show `Graph` component without requiring a button
- filter graph data by the selected date range
- add gold price in USD and use a secondary axis so inflation is visible

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6873ea182c24832787020c7d396a733d