### PR TITLE
Add normalized financial graphs

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,4 +1,3 @@
-<!-- Version 2.2.2 -->
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/server.js
+++ b/server.js
@@ -1,4 +1,3 @@
-// Version 2.2.2
 const express = require('express');
 const cors = require('cors');
 const xlsx = require('xlsx');

--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,3 @@
-/* Version 2.2.2 */
 /* Genel Stil */
 body {
   font-family: 'Poppins', sans-serif;

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,3 @@
-// Version 2.2.2
 import React, { useState, useEffect } from "react";
 import "./App.css";
 import ComparisonTable from "./components/ComparisonTable";

--- a/src/components/ComparisonChart.js
+++ b/src/components/ComparisonChart.js
@@ -1,4 +1,3 @@
-// Version 2.2.2
 import React from "react";
 import { Bar } from "react-chartjs-2";
 

--- a/src/components/ComparisonTable.js
+++ b/src/components/ComparisonTable.js
@@ -1,4 +1,3 @@
-// Version 2.2.2
 import React from "react";
 import { calculateValues } from "../utils/calculateValues";
 

--- a/src/components/DataChart.js
+++ b/src/components/DataChart.js
@@ -1,4 +1,3 @@
-// Version 2.2.2
 import React from "react";
 import {
   LineChart,

--- a/src/components/DataForm.js
+++ b/src/components/DataForm.js
@@ -1,4 +1,3 @@
-// Version 2.2.2
 import React, { useState } from "react";
 
 const DataForm = ({ onFilter }) => {

--- a/src/components/Filters.js
+++ b/src/components/Filters.js
@@ -1,4 +1,3 @@
-// Version 2.2.2
 import React from "react";
 
 function Filters({

--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -1,4 +1,3 @@
-// Version 2.2.2
 import React from "react";
 import { Line } from "react-chartjs-2";
 import "chart.js/auto";
@@ -14,29 +13,67 @@ const Graph = ({ data, startDate, endDate }) => {
            (!endDate || item.Date <= endDate);
   });
 
+  if (filtered.length === 0) return null;
+
+  const first = filtered[0];
+
+  const getInflation = (item) => item.InflationIndex ?? item.TRYInflationIndex;
+
   const chartData = {
     labels: filtered.map((item) => item.Date),
     datasets: [
       {
         label: "Enflasyon Endeksi",
-        data: filtered.map((item) => item.InflationIndex),
+        data: filtered.map((item) => getInflation(item) / getInflation(first)),
         borderColor: "rgba(75,192,192,1)",
         fill: false,
-        yAxisID: "yInflation",
       },
       {
         label: "Altın Fiyatı (Gram/TRY)",
-        data: filtered.map((item) => item.GoldPerGramTRY),
+        data: filtered.map((item) => item.GoldPerGramTRY / first.GoldPerGramTRY),
         borderColor: "rgba(255,99,132,1)",
         fill: false,
-        yAxisID: "yPrice",
       },
       {
         label: "Altın Fiyatı (Gram/USD)",
-        data: filtered.map((item) => item.GoldPerGramTRY / item.USDTRY),
+        data: filtered.map(
+          (item) => (item.GoldPerGramTRY / item.USDTRY) /
+                    (first.GoldPerGramTRY / first.USDTRY)
+        ),
         borderColor: "rgba(54,162,235,1)",
         fill: false,
-        yAxisID: "yPrice",
+      },
+      {
+        label: "USD/TRY",
+        data: filtered.map((item) => item.USDTRY / first.USDTRY),
+        borderColor: "rgba(255,159,64,1)",
+        fill: false,
+      },
+      {
+        label: "EUR/TRY",
+        data: filtered.map((item) => item.EURTRY / first.EURTRY),
+        borderColor: "rgba(153,102,255,1)",
+        fill: false,
+      },
+      {
+        label: "Asgari Ücret (TRY)",
+        data: filtered.map((item) => item.minWageNetTRY / first.minWageNetTRY),
+        borderColor: "rgba(255,205,86,1)",
+        fill: false,
+      },
+      {
+        label: "Asgari Ücret (USD)",
+        data: filtered.map((item) => item.minWageNetUSD / first.minWageNetUSD),
+        borderColor: "rgba(201,203,207,1)",
+        fill: false,
+      },
+      {
+        label: "Normalize TRY",
+        data: filtered.map(
+          (item) => item.USDTRY_TRY_NORM / first.USDTRY_TRY_NORM
+        ),
+        borderColor: "rgba(75,192,192,0.5)",
+        fill: false,
       },
     ],
   };
@@ -44,20 +81,15 @@ const Graph = ({ data, startDate, endDate }) => {
   const options = {
     responsive: true,
     scales: {
-      yInflation: {
-        position: "left",
+      y: {
         ticks: { callback: (val) => val.toFixed(2) },
-      },
-      yPrice: {
-        position: "right",
-        grid: { drawOnChartArea: false },
       },
     },
   };
 
   return (
     <div>
-      <h3>Enflasyon ve Altın Fiyatı</h3>
+      <h3>Enflasyon ve Finansal Göstergeler</h3>
       <Line data={chartData} options={options} />
     </div>
   );

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -1,4 +1,3 @@
-// Version 2.2.2
 import React from "react";
 
 const Table = ({ data }) => (

--- a/src/components/TrendChart.js
+++ b/src/components/TrendChart.js
@@ -1,4 +1,3 @@
-// Version 2.2.2
 import React, { useEffect, useRef } from "react";
 import {
   Chart as ChartJS,

--- a/src/fetchData.js
+++ b/src/fetchData.js
@@ -1,4 +1,3 @@
-// Version 2.2.2
 //import data from './data.json'; with fetch using plain JavaScript
 
 const fetchData = async () => {

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,3 @@
-/* Version 2.2.2 */
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-// Version 2.2.2
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import 'bootstrap/dist/css/bootstrap.min.css';

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,4 +1,3 @@
-/* Version 2.2.2 */
 .app {
   text-align: center;
   font-family: Arial, sans-serif;

--- a/src/util.js
+++ b/src/util.js
@@ -1,4 +1,3 @@
-// Version 2.2.2
 const fs = require('fs');
 const path = require('path');
 

--- a/src/util2.js
+++ b/src/util2.js
@@ -1,4 +1,3 @@
-// Version 2.2.2
 const xlsx = require("xlsx");
 const fs = require("fs");
 const path = require("path");

--- a/src/utils/calculateValues.js
+++ b/src/utils/calculateValues.js
@@ -1,4 +1,3 @@
-// Version 2.2.2
 export const calculateValues = (data, baseCurrency, startDate, endDate, amount) => {
   if (!data || !startDate || !endDate) {
     return { startValues: null, endValues: null };

--- a/src/utils/calculateValues.test.js
+++ b/src/utils/calculateValues.test.js
@@ -1,4 +1,3 @@
-// Version 2.2.2
 import { calculateValues } from './calculateValues';
 
 const mockData = [

--- a/src/utils/calculations.js
+++ b/src/utils/calculations.js
@@ -1,4 +1,3 @@
-// Version 2.2.2
 export async function fetchData() {
   const response = await fetch("/api/data");
   return response.json();


### PR DESCRIPTION
## Summary
- normalize charts so each data series starts at 1x
- add USD/TRY, EUR/TRY, minimum wage TRY & USD, and normalized TRY to `Graph`
- remove version comments from source

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6873edd68b34832785279f5a59750b83