### PR TITLE
Handle date limits, theme updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purchase-power-3",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.14.1",

--- a/src/App.css
+++ b/src/App.css
@@ -3,10 +3,17 @@ body {
   font-family: 'Poppins', sans-serif;
   margin: 0;
   padding: 0;
-  background: linear-gradient(135deg, #e0e4ec 0%, #a6b0c1 100%);
+  background: linear-gradient(135deg, #e0e4ec 0%, #bfc3ca 100%);
   color: #222222;
   min-height: 100vh;
   font-size: 0.95rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #000000;
+    color: #dddddd;
+  }
 }
 
 h1 {

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import "./App.css";
 import ComparisonTable from "./components/ComparisonTable";
 import Graph from "./components/Graph";
+import packageJson from "../package.json";
 
 const logoUrl = "/logo.svg";
 
@@ -9,7 +10,7 @@ function App() {
   const [data, setData] = useState([]);
   const [baseCurrency, setBaseCurrency] = useState("TRY"); // Baz para birimi
   const [startDate, setStartDate] = useState("2022-01");
-  const [endDate, setEndDate] = useState("2025-01");
+  const [endDate, setEndDate] = useState("2024-12");
   const [amount, setAmount] = useState(100); // Başlangıç miktarı
 
   useEffect(() => {
@@ -53,7 +54,7 @@ function App() {
       />
       <Graph data={data} startDate={startDate} endDate={endDate} />
       <footer className="text-center mt-4">
-        Developed by Mustafa Evleksiz - Version 2.2.3 © {new Date().getFullYear()}
+        Developed by Mustafa Evleksiz - Version {packageJson.version} © {new Date().getFullYear()}
       </footer>
     </div>
   );

--- a/src/components/ComparisonTable.js
+++ b/src/components/ComparisonTable.js
@@ -1,6 +1,14 @@
 import React from "react";
 import { calculateValues } from "../utils/calculateValues";
 
+const adjustMonth = (date, diff) => {
+  const [y, m] = date.split("-").map(Number);
+  const d = new Date(y, m - 1 + diff);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  return `${year}-${month}`;
+};
+
 function ComparisonTable({
   data,
   baseCurrency,
@@ -12,6 +20,8 @@ function ComparisonTable({
   setEndDate,
   setAmount,
 }) {
+  const incStartDate = (diff) => setStartDate(adjustMonth(startDate, diff));
+  const incEndDate = (diff) => setEndDate(adjustMonth(endDate, diff));
   const { startValues, endValues } = calculateValues(
     data,
     baseCurrency,
@@ -50,25 +60,35 @@ function ComparisonTable({
             </th>
             <th>
               <label htmlFor="startDate">Başlangıç Tarihi:</label>
-              <input
-                type="month"
-                id="startDate"
-                value={startDate}
-                onChange={(e) => setStartDate(e.target.value)}
-                min="1980-01"
-                max="2025-01"
-              />
+              <div className="d-flex align-items-center gap-1">
+                <button type="button" onClick={() => incStartDate(-1)}>-</button>
+                <input
+                  type="month"
+                  id="startDate"
+                  value={startDate}
+                  onChange={(e) => setStartDate(e.target.value)}
+                  min="1980-01"
+                  max="2024-12"
+                  step="1"
+                />
+                <button type="button" onClick={() => incStartDate(1)}>+</button>
+              </div>
             </th>
             <th>
               <label htmlFor="endDate">Bitiş Tarihi:</label>
-              <input
-                type="month"
-                id="endDate"
-                value={endDate}
-                onChange={(e) => setEndDate(e.target.value)}
-                min="1980-01"
-                max="2025-01"
-              />
+              <div className="d-flex align-items-center gap-1">
+                <button type="button" onClick={() => incEndDate(-1)}>-</button>
+                <input
+                  type="month"
+                  id="endDate"
+                  value={endDate}
+                  onChange={(e) => setEndDate(e.target.value)}
+                  min="1980-01"
+                  max="2024-12"
+                  step="1"
+                />
+                <button type="button" onClick={() => incEndDate(1)}>+</button>
+              </div>
             </th>
           </tr>
         </thead>

--- a/src/utils/calculateValues.js
+++ b/src/utils/calculateValues.js
@@ -3,8 +3,21 @@ export const calculateValues = (data, baseCurrency, startDate, endDate, amount) 
     return { startValues: null, endValues: null };
   }
 
-  const startData = data.find((item) => item.Date === startDate);
-  const endData = data.find((item) => item.Date === endDate);
+  const parse = (d) => parseInt(d.replace('-', ''), 10);
+  const min = data[0].Date;
+  const max = data[data.length - 1].Date;
+
+  let startData = data.find((item) => item.Date === startDate);
+  if (!startData) {
+    if (parse(startDate) < parse(min)) startData = data[0];
+    else if (parse(startDate) > parse(max)) startData = data[data.length - 1];
+  }
+
+  let endData = data.find((item) => item.Date === endDate);
+  if (!endData) {
+    if (parse(endDate) < parse(min)) endData = data[0];
+    else if (parse(endDate) > parse(max)) endData = data[data.length - 1];
+  }
 
   if (!startData || !endData) {
     return { startValues: null, endValues: null };


### PR DESCRIPTION
## Summary
- clamp dates in `calculateValues` so out-of-range values do not break the UI
- add increment/decrement controls to month selectors
- support dark mode background
- show version from `package.json` in the footer and bump version

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6873fae2d6d48327bed2fd7fc39904d0