### PR TITLE
Fix empty data handling in calculateValues

### DIFF
--- a/src/utils/calculateValues.js
+++ b/src/utils/calculateValues.js
@@ -1,5 +1,5 @@
 export const calculateValues = (data, baseCurrency, startDate, endDate, amount) => {
-  if (!data || !startDate || !endDate) {
+  if (!Array.isArray(data) || data.length === 0 || !startDate || !endDate) {
     return { startValues: null, endValues: null };
   }
 


### PR DESCRIPTION
## Summary
- handle empty data arrays in `calculateValues`

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687402ddb7888327ab671b17a164e554