### PR TITLE
Modernize dark theme

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
+    <meta name="color-scheme" content="light dark" />
     <meta
       name="description"
       content="Geçmiş ve güncel değerleri karşılaştırmak için alım gücü hesaplama uygulaması"

--- a/src/App.css
+++ b/src/App.css
@@ -3,7 +3,7 @@ body {
   font-family: 'Poppins', sans-serif;
   margin: 0;
   padding: 0;
-  background: linear-gradient(135deg, #e0e4ec 0%, #bfc3ca 100%);
+  background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
   color: #222222;
   min-height: 100vh;
   font-size: 0.95rem;
@@ -27,8 +27,45 @@ body {
 
 @media (prefers-color-scheme: dark) {
   body {
-    background: #000000;
-    color: #dddddd;
+    background: #181818;
+    color: #e0e0e0;
+  }
+
+  .filters,
+  .comparison-table {
+    background-color: #222222;
+    color: #e0e0e0;
+    border-color: #444444;
+  }
+
+  .filters input,
+  .filters select,
+  .comparison-table input,
+  .comparison-table select {
+    background: #2c2c2c;
+    border-color: #444444;
+    color: #e0e0e0;
+  }
+
+  .comparison-table tr:nth-child(even) {
+    background-color: #262626;
+  }
+
+  .comparison-table tr:hover {
+    background-color: #333333;
+  }
+
+  .comparison-table td {
+    color: #e0e0e0;
+  }
+
+  button {
+    background: #1a73e8;
+    color: #ffffff;
+  }
+
+  button:hover {
+    background: #1669c1;
   }
 }
 
@@ -170,6 +207,20 @@ th > select {
 input:focus,
 select:focus {
   border: 2px solid #0d6efd;
+}
+
+button {
+  padding: 5px 10px;
+  border: none;
+  border-radius: 4px;
+  background: #0d6efd;
+  color: #ffffff;
+  cursor: pointer;
+  transition: background 0.2s ease-in-out;
+}
+
+button:hover {
+  background: #0b5ed7;
 }
 
 /* Responsive */

--- a/src/components/ComparisonChart.js
+++ b/src/components/ComparisonChart.js
@@ -24,9 +24,23 @@ function ComparisonChart({ data, baseCurrency }) {
     ],
   };
 
+  const darkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const axisColor = darkMode ? '#e0e0e0' : '#222';
+  const gridColor = darkMode ? '#444' : '#ccc';
+
+  const options = {
+    scales: {
+      x: { ticks: { color: axisColor }, grid: { color: gridColor } },
+      y: { ticks: { color: axisColor }, grid: { color: gridColor } },
+    },
+    plugins: {
+      legend: { labels: { color: axisColor } },
+    },
+  };
+
   return (
     <div style={{ width: "80%", margin: "auto" }}>
-      <Bar data={chartData} />
+      <Bar data={chartData} options={options} />
     </div>
   );
 }

--- a/src/components/DataChart.js
+++ b/src/components/DataChart.js
@@ -11,14 +11,18 @@ import {
 } from "recharts";
 
 const DataChart = ({ data }) => {
+  const darkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const axisColor = darkMode ? '#e0e0e0' : '#222';
+  const gridColor = darkMode ? '#444' : '#ccc';
+
   return (
     <ResponsiveContainer width="100%" height={400}>
       <LineChart data={data}>
-        <CartesianGrid stroke="#ccc" />
-        <XAxis dataKey="Date" />
-        <YAxis />
-        <Tooltip />
-        <Legend />
+        <CartesianGrid stroke={gridColor} />
+        <XAxis dataKey="Date" stroke={axisColor} tick={{ fill: axisColor }} />
+        <YAxis stroke={axisColor} tick={{ fill: axisColor }} />
+        <Tooltip contentStyle={{ background: darkMode ? '#333' : '#fff', color: axisColor }} />
+        <Legend wrapperStyle={{ color: axisColor }} />
         <Line
           type="monotone"
           dataKey="adjustedAmount"

--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -78,12 +78,28 @@ const Graph = ({ data, startDate, endDate }) => {
     ],
   };
 
+  const darkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const axisColor = darkMode ? '#e0e0e0' : '#222';
+  const gridColor = darkMode ? '#444' : '#ccc';
+
   const options = {
     responsive: true,
     scales: {
-      y: {
-        ticks: { callback: (val) => val.toFixed(2) },
+      x: {
+        ticks: { color: axisColor },
+        grid: { color: gridColor },
       },
+      y: {
+        ticks: {
+          color: axisColor,
+          callback: (val) => val.toFixed(2),
+        },
+        grid: { color: gridColor },
+      },
+    },
+    plugins: {
+      legend: { labels: { color: axisColor } },
+      title: { color: axisColor },
     },
   };
 

--- a/src/components/TrendChart.js
+++ b/src/components/TrendChart.js
@@ -52,12 +52,26 @@ function TrendChart({ data, baseCurrency, initialValue }) {
       ],
     };
 
+    const darkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const axisColor = darkMode ? '#e0e0e0' : '#222';
+    const gridColor = darkMode ? '#444' : '#ccc';
+
     // Grafik ayarları
     const chartOptions = {
       responsive: true,
+      scales: {
+        x: {
+          ticks: { color: axisColor },
+          grid: { color: gridColor },
+        },
+        y: {
+          ticks: { color: axisColor },
+          grid: { color: gridColor },
+        },
+      },
       plugins: {
-        legend: { display: true },
-        title: { display: true, text: "Zamanla Değişim Grafiği" },
+        legend: { display: true, labels: { color: axisColor } },
+        title: { display: true, text: "Zamanla Değişim Grafiği", color: axisColor },
       },
     };
 


### PR DESCRIPTION
## Summary
- update gradient background
- add color scheme meta tag
- add dark-mode friendly colors
- style buttons for light and dark mode
- improve dark mode readability for inputs and charts

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68740804784883279c17318b9266f115