### PR TITLE
Address dark background

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
+    <meta name="color-scheme" content="light dark" />
     <meta
       name="description"
       content="Geçmiş ve güncel değerleri karşılaştırmak için alım gücü hesaplama uygulaması"

--- a/src/App.css
+++ b/src/App.css
@@ -3,7 +3,7 @@ body {
   font-family: 'Poppins', sans-serif;
   margin: 0;
   padding: 0;
-  background: linear-gradient(135deg, #e0e4ec 0%, #bfc3ca 100%);
+  background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
   color: #222222;
   min-height: 100vh;
   font-size: 0.95rem;
@@ -27,8 +27,68 @@ body {
 
 @media (prefers-color-scheme: dark) {
   body {
-    background: #000000;
-    color: #dddddd;
+    background: linear-gradient(135deg, #25272e 0%, #181a20 100%);
+    color: #e8e8e8;
+  }
+
+  .filters,
+  .comparison-table {
+    background-color: rgba(41, 43, 51, 0.85);
+    color: #e8e8e8;
+    border-color: #555555;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(6px);
+  }
+
+  .filters input,
+  .filters select,
+  .comparison-table input,
+  .comparison-table select {
+    background: #30333b;
+    border-color: #555555;
+    color: #e8e8e8;
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.6);
+  }
+
+  .comparison-table tr:nth-child(even) {
+    background-color: #2f3038;
+  }
+
+  .comparison-table tr:hover {
+    background-color: #3a3b42;
+  }
+
+  .comparison-table td {
+    color: #e8e8e8;
+  }
+
+  .filters label {
+    color: #e8e8e8;
+  }
+
+  button {
+    background: #3a78ff;
+    color: #ffffff;
+  }
+
+  button:hover {
+    background: #2c64e2;
+  }
+
+  .filters input:hover,
+  .filters select:hover,
+  .comparison-table input:hover,
+  .comparison-table select:hover {
+    background: #353841;
+    border-color: #3a78ff;
+  }
+
+  .filters input:focus,
+  .filters select:focus,
+  .comparison-table input:focus,
+  .comparison-table select:focus {
+    border-color: #3a78ff;
+    outline: none;
   }
 }
 
@@ -41,6 +101,12 @@ h1 {
   text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.2);
 }
 
+@media (prefers-color-scheme: dark) {
+  h1 {
+    color: #9cc3ff;
+  }
+}
+
 /* Filtre Alanı */
 .filters {
   display: flex;
@@ -48,10 +114,11 @@ h1 {
   flex-wrap: wrap;
   margin: 20px auto;
   padding: 20px;
-  background-color: #FFFFFF;
+  background-color: rgba(255, 255, 255, 0.85);
   border: 1px solid #E0E0E0;
   border-radius: 12px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  backdrop-filter: blur(6px);
   max-width: 1200px;
 }
 
@@ -92,10 +159,11 @@ h1 {
   margin: 20px auto;
   border-collapse: separate;
   border-spacing: 0;
-  background: #FFFFFF;
+  background: rgba(255, 255, 255, 0.9);
   border-radius: 12px;
   overflow: hidden;
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.1);
+  backdrop-filter: blur(6px);
 }
 
 .comparison-table th,
@@ -170,6 +238,20 @@ th > select {
 input:focus,
 select:focus {
   border: 2px solid #0d6efd;
+}
+
+button {
+  padding: 5px 10px;
+  border: none;
+  border-radius: 4px;
+  background: #0d6efd;
+  color: #ffffff;
+  cursor: pointer;
+  transition: background 0.2s ease-in-out;
+}
+
+button:hover {
+  background: #0b5ed7;
 }
 
 /* Responsive */

--- a/src/components/ComparisonChart.js
+++ b/src/components/ComparisonChart.js
@@ -24,9 +24,23 @@ function ComparisonChart({ data, baseCurrency }) {
     ],
   };
 
+  const darkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const axisColor = darkMode ? '#e0e0e0' : '#222';
+  const gridColor = darkMode ? '#444' : '#ccc';
+
+  const options = {
+    scales: {
+      x: { ticks: { color: axisColor }, grid: { color: gridColor } },
+      y: { ticks: { color: axisColor }, grid: { color: gridColor } },
+    },
+    plugins: {
+      legend: { labels: { color: axisColor } },
+    },
+  };
+
   return (
     <div style={{ width: "80%", margin: "auto" }}>
-      <Bar data={chartData} />
+      <Bar data={chartData} options={options} />
     </div>
   );
 }

--- a/src/components/DataChart.js
+++ b/src/components/DataChart.js
@@ -11,14 +11,18 @@ import {
 } from "recharts";
 
 const DataChart = ({ data }) => {
+  const darkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const axisColor = darkMode ? '#e0e0e0' : '#222';
+  const gridColor = darkMode ? '#444' : '#ccc';
+
   return (
     <ResponsiveContainer width="100%" height={400}>
       <LineChart data={data}>
-        <CartesianGrid stroke="#ccc" />
-        <XAxis dataKey="Date" />
-        <YAxis />
-        <Tooltip />
-        <Legend />
+        <CartesianGrid stroke={gridColor} />
+        <XAxis dataKey="Date" stroke={axisColor} tick={{ fill: axisColor }} />
+        <YAxis stroke={axisColor} tick={{ fill: axisColor }} />
+        <Tooltip contentStyle={{ background: darkMode ? '#333' : '#fff', color: axisColor }} />
+        <Legend wrapperStyle={{ color: axisColor }} />
         <Line
           type="monotone"
           dataKey="adjustedAmount"

--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -78,12 +78,28 @@ const Graph = ({ data, startDate, endDate }) => {
     ],
   };
 
+  const darkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const axisColor = darkMode ? '#e0e0e0' : '#222';
+  const gridColor = darkMode ? '#444' : '#ccc';
+
   const options = {
     responsive: true,
     scales: {
-      y: {
-        ticks: { callback: (val) => val.toFixed(2) },
+      x: {
+        ticks: { color: axisColor },
+        grid: { color: gridColor },
       },
+      y: {
+        ticks: {
+          color: axisColor,
+          callback: (val) => val.toFixed(2),
+        },
+        grid: { color: gridColor },
+      },
+    },
+    plugins: {
+      legend: { labels: { color: axisColor } },
+      title: { color: axisColor },
     },
   };
 

--- a/src/components/TrendChart.js
+++ b/src/components/TrendChart.js
@@ -52,12 +52,26 @@ function TrendChart({ data, baseCurrency, initialValue }) {
       ],
     };
 
+    const darkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const axisColor = darkMode ? '#e0e0e0' : '#222';
+    const gridColor = darkMode ? '#444' : '#ccc';
+
     // Grafik ayarları
     const chartOptions = {
       responsive: true,
+      scales: {
+        x: {
+          ticks: { color: axisColor },
+          grid: { color: gridColor },
+        },
+        y: {
+          ticks: { color: axisColor },
+          grid: { color: gridColor },
+        },
+      },
       plugins: {
-        legend: { display: true },
-        title: { display: true, text: "Zamanla Değişim Grafiği" },
+        legend: { display: true, labels: { color: axisColor } },
+        title: { display: true, text: "Zamanla Değişim Grafiği", color: axisColor },
       },
     };
 


### PR DESCRIPTION
## Summary
- lighten dark mode backgrounds for readability
- add subtle blur and box shadows for a more modern look
- tweak hover and focus styles in dark mode

## Testing
- `yarn install`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68740804784883279c17318b9266f115