### PR TITLE
Fix dark mode input readability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purchase-power-3",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.14.1",

--- a/src/App.css
+++ b/src/App.css
@@ -60,6 +60,18 @@ body {
     color: var(--text-dark);
   }
 
+  input[type="number"],
+  input[type="month"],
+  select {
+    background: var(--input-dark);
+    border-color: #444444;
+    color: var(--text-dark);
+  }
+
+  .filters label {
+    color: var(--text-dark);
+  }
+
   .comparison-table tr:nth-child(even) {
     background-color: var(--row-dark);
   }
@@ -202,6 +214,7 @@ select {
   width: 90%;
   box-sizing: border-box;
   background: #F9F9F9;
+  color: #222222;
 }
 
 th > label,


### PR DESCRIPTION
## Summary
- tweak input styles so they remain readable in dark mode
- bump project version to 2.2.6

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68741aa81f448327a481318b8f24a019