### PR TITLE
Update UI for mobile, add dark mode toggle

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -24,7 +24,7 @@ body {
   );
   color: var(--text-light);
   min-height: 100vh;
-  font-size: 0.95rem;
+  font-size: 0.85rem;
   transition: background 0.3s ease;
 }
 
@@ -94,11 +94,54 @@ body {
   }
 }
 
+body.dark-mode {
+  background: var(--bg-dark);
+  color: var(--text-dark);
+}
+
+body.dark-mode .filters,
+body.dark-mode .comparison-table {
+  background-color: var(--surface-dark);
+  color: var(--text-dark);
+  border-color: #444444;
+}
+
+body.dark-mode .filters input,
+body.dark-mode .filters select,
+body.dark-mode input[type="number"],
+body.dark-mode input[type="month"],
+body.dark-mode select {
+  background: var(--input-dark);
+  border-color: #444444;
+  color: var(--text-dark);
+}
+
+body.dark-mode .filters label {
+  color: var(--text-dark);
+}
+
+body.dark-mode .comparison-table tr:nth-child(even) {
+  background-color: var(--row-dark);
+}
+
+body.dark-mode .comparison-table tr:hover {
+  background-color: var(--hover-dark);
+}
+
+body.dark-mode button {
+  background: #1a73e8;
+  color: #ffffff;
+}
+
+body.dark-mode button:hover {
+  background: #1669c1;
+}
+
 h1 {
   text-align: center;
   margin: 20px 0;
   color: var(--primary-color);
-  font-size: 2.2rem;
+  font-size: 1.6rem;
   font-weight: 600;
   text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.2);
 }
@@ -162,7 +205,7 @@ h1 {
 
 .comparison-table th,
 .comparison-table td {
-  padding: 15px;
+  padding: 10px;
   text-align: center;
   border: none;
 }
@@ -171,7 +214,7 @@ h1 {
   background: var(--primary-color);
   color: #ffffff;
   text-transform: uppercase;
-  font-size: 0.9rem;
+  font-size: 0.8rem;
   font-weight: 600;
   position: sticky;
   top: 0;
@@ -197,7 +240,7 @@ h1 {
 }
 
 .comparison-table td {
-  font-size: 0.95rem;
+  font-size: 0.85rem;
   color: #222222;
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ function App() {
   const [startDate, setStartDate] = useState("2020-01");
   const [endDate, setEndDate] = useState("2025-07");
   const [amount, setAmount] = useState(100); // Başlangıç miktarı
+  const [darkMode, setDarkMode] = useState(false);
 
   useEffect(() => {
     const loadData = async () => {
@@ -35,11 +36,24 @@ function App() {
     loadData();
   }, []);
 
+  useEffect(() => {
+    document.body.classList.toggle("dark-mode", darkMode);
+  }, [darkMode]);
+
   return (
-    <div className="container py-4 fade-in">
-      <header className="text-center mb-4 fade-in">
-        <img src={logoUrl} alt="Alim Gucu" style={{ height: "60px" }} />
-        <h1>Para Değeri Karşılaştırma</h1>
+    <div className="container-fluid py-4 px-2 fade-in">
+      <header className="d-flex justify-content-between align-items-center mb-4 fade-in">
+        <div className="d-flex align-items-center gap-2">
+          <img src={logoUrl} alt="Alim Gucu" style={{ height: "60px" }} />
+          <h1 className="mb-0">Para Değeri Karşılaştırma</h1>
+        </div>
+        <button
+          className="btn btn-sm btn-secondary"
+          onClick={() => setDarkMode(!darkMode)}
+          aria-label="tema değiştir"
+        >
+          {darkMode ? "☀️" : "🌙"}
+        </button>
       </header>
       <ComparisonTable
         data={data}

--- a/src/components/ComparisonTable.js
+++ b/src/components/ComparisonTable.js
@@ -58,8 +58,8 @@ function ComparisonTable({
                 <option value="USD">USD</option>
               </select>
             </th>
-            <th>
-              <label htmlFor="startDate">Başlangıç Tarihi:</label>
+            <th className="align-top">
+              <label htmlFor="startDate">Başlangıç</label>
               <div className="d-flex align-items-center gap-1">
                 <button type="button" onClick={() => incStartDate(-1)}>-</button>
                 <input
@@ -74,8 +74,8 @@ function ComparisonTable({
                 <button type="button" onClick={() => incStartDate(1)}>+</button>
               </div>
             </th>
-            <th>
-              <label htmlFor="endDate">Bitiş Tarihi:</label>
+            <th className="align-top">
+              <label htmlFor="endDate">Bitiş</label>
               <div className="d-flex align-items-center gap-1">
                 <button type="button" onClick={() => incEndDate(-1)}>-</button>
                 <input
@@ -94,12 +94,12 @@ function ComparisonTable({
         </thead>
         <tbody>
           <tr>
-            <td>TRY Karşılığı</td>
+            <td>₺</td>
             <td>{startValues.tryValue.toFixed(2)}</td>
             <td>{endValues.tryValue.toFixed(2)}</td>
           </tr>
           <tr>
-            <td>USD Karşılığı</td>
+            <td>$</td>
             <td>
               {startValues.usdValue.toFixed(2)} ($: {data.find(d => d.Date === startDate)?.USDTRY})
             </td>
@@ -108,7 +108,7 @@ function ComparisonTable({
             </td>
           </tr>
           <tr>
-            <td>EUR Karşılığı</td>
+            <td>€</td>
             <td>
               {startValues.eurValue.toFixed(2)} (€: {data.find(d => d.Date === startDate)?.EURTRY})
             </td>
@@ -117,7 +117,7 @@ function ComparisonTable({
             </td>
           </tr>
           <tr>
-            <td>Altın Karşılığı (gram)</td>
+            <td>🏅</td>
             <td>
               {startValues.goldValue.toFixed(1)} (₺: {data.find(d => d.Date === startDate)?.GoldPerGramTRY})
             </td>
@@ -126,7 +126,7 @@ function ComparisonTable({
             </td>
           </tr>
           <tr>
-            <td>Asgari Ücret Karşılığı</td>
+            <td>👨🏼‍🔧</td>
             <td>
               {startValues.minWageRatio.toFixed(2)}× (₺: {data.find(d => d.Date === startDate)?.minWageNetTRY})
             </td>
@@ -135,11 +135,7 @@ function ComparisonTable({
             </td>
           </tr>
           <tr>
-            <td>
-              {baseCurrency === "TRY"
-                ? "Normalize Edilmiş USD Karşılığı"
-                : "Normalize Edilmiş TRY Karşılığı"}
-            </td>
+            <td>{baseCurrency === "TRY" ? "⊴$⊵" : "⊴₺⊵"}</td>
             <td>{startValues.normalizedValue.toFixed(2)}</td>
             <td>{endValues.normalizedValue.toFixed(2)}</td>
           </tr>


### PR DESCRIPTION
## Summary
- shrink base font size and table spacing for smaller screens
- add manual dark mode styles and toggle button
- display heading beside logo
- replace currency labels with icons
- tweak start/end labels and alignment

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68750f435b24832791bf88c0019495a8