### PR TITLE
Implement requested UI improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purchase-power-3",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.14.1",

--- a/src/App.css
+++ b/src/App.css
@@ -24,8 +24,20 @@ body {
   );
   color: var(--text-light);
   min-height: 100vh;
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   transition: background 0.3s ease;
+}
+
+@media (max-width: 768px) {
+  body {
+    font-size: 0.8rem;
+  }
+}
+
+@media (min-width: 1200px) {
+  body {
+    font-size: 1rem;
+  }
 }
 
 /* Basit fade-in animasyonu */
@@ -364,4 +376,41 @@ button:active {
   .fade-in {
     animation-duration: 0.8s;
   }
+}
+
+.orientation-hint {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  padding: 8px 16px;
+  border-radius: 8px;
+  z-index: 1050;
+  animation: fadeOutHint 0.5s ease 4.5s forwards;
+}
+
+@keyframes fadeOutHint {
+  to {
+    opacity: 0;
+  }
+}
+
+.icon-tooltip {
+  position: absolute;
+  bottom: -1.8em;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.75);
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+
+.icon-cell {
+  position: relative;
+  cursor: pointer;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import "./App.css";
 import ComparisonTable from "./components/ComparisonTable";
 import Graph from "./components/Graph";
+import OrientationHint from "./components/OrientationHint";
 import packageJson from "../package.json";
 
 const logoUrl = "/logo.svg";
@@ -12,7 +13,9 @@ function App() {
   const [startDate, setStartDate] = useState("2020-01");
   const [endDate, setEndDate] = useState("2025-07");
   const [amount, setAmount] = useState(100); // Başlangıç miktarı
-  const [darkMode, setDarkMode] = useState(false);
+  const [darkMode, setDarkMode] = useState(() =>
+    window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+  );
 
   useEffect(() => {
     const loadData = async () => {
@@ -42,6 +45,7 @@ function App() {
 
   return (
     <div className="container-fluid py-4 px-2 fade-in">
+      <OrientationHint />
       <header className="d-flex justify-content-between align-items-center mb-4 fade-in">
         <div className="d-flex align-items-center gap-2">
           <img src={logoUrl} alt="Alim Gucu" style={{ height: "60px" }} />

--- a/src/components/ComparisonTable.js
+++ b/src/components/ComparisonTable.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { calculateValues } from "../utils/calculateValues";
 
 const adjustMonth = (date, diff) => {
@@ -22,6 +22,7 @@ function ComparisonTable({
 }) {
   const incStartDate = (diff) => setStartDate(adjustMonth(startDate, diff));
   const incEndDate = (diff) => setEndDate(adjustMonth(endDate, diff));
+  const [tooltip, setTooltip] = useState(null);
   const { startValues, endValues } = calculateValues(
     data,
     baseCurrency,
@@ -60,8 +61,8 @@ function ComparisonTable({
             </th>
             <th className="align-top">
               <label htmlFor="startDate">Başlangıç</label>
-              <div className="d-flex align-items-center gap-1">
-                <button type="button" onClick={() => incStartDate(-1)}>-</button>
+              <div className="d-flex flex-column align-items-center gap-1">
+                <button type="button" onClick={() => incStartDate(1)}>+</button>
                 <input
                   type="month"
                   id="startDate"
@@ -71,13 +72,13 @@ function ComparisonTable({
                   max="2025-07"
                   step="1"
                 />
-                <button type="button" onClick={() => incStartDate(1)}>+</button>
+                <button type="button" onClick={() => incStartDate(-1)}>-</button>
               </div>
             </th>
             <th className="align-top">
               <label htmlFor="endDate">Bitiş</label>
-              <div className="d-flex align-items-center gap-1">
-                <button type="button" onClick={() => incEndDate(-1)}>-</button>
+              <div className="d-flex flex-column align-items-center gap-1">
+                <button type="button" onClick={() => incEndDate(1)}>+</button>
                 <input
                   type="month"
                   id="endDate"
@@ -87,19 +88,23 @@ function ComparisonTable({
                   max="2025-07"
                   step="1"
                 />
-                <button type="button" onClick={() => incEndDate(1)}>+</button>
+                <button type="button" onClick={() => incEndDate(-1)}>-</button>
               </div>
             </th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td>₺</td>
+            <td className="icon-cell" onClick={() => setTooltip(tooltip==='try'?null:'try')}>₺
+              {tooltip==='try' && <div className="icon-tooltip">Türk lirası karşılığı</div>}
+            </td>
             <td>{startValues.tryValue.toFixed(2)}</td>
             <td>{endValues.tryValue.toFixed(2)}</td>
           </tr>
           <tr>
-            <td>$</td>
+            <td className="icon-cell" onClick={() => setTooltip(tooltip==='usd'?null:'usd')}>$
+              {tooltip==='usd' && <div className="icon-tooltip">ABD doları karşılığı</div>}
+            </td>
             <td>
               {startValues.usdValue.toFixed(2)} ($: {data.find(d => d.Date === startDate)?.USDTRY})
             </td>
@@ -108,7 +113,9 @@ function ComparisonTable({
             </td>
           </tr>
           <tr>
-            <td>€</td>
+            <td className="icon-cell" onClick={() => setTooltip(tooltip==='eur'?null:'eur')}>€
+              {tooltip==='eur' && <div className="icon-tooltip">Euro karşılığı</div>}
+            </td>
             <td>
               {startValues.eurValue.toFixed(2)} (€: {data.find(d => d.Date === startDate)?.EURTRY})
             </td>
@@ -117,7 +124,9 @@ function ComparisonTable({
             </td>
           </tr>
           <tr>
-            <td>🏅</td>
+            <td className="icon-cell" onClick={() => setTooltip(tooltip==='gold'?null:'gold')}>🏅
+              {tooltip==='gold' && <div className="icon-tooltip">Gram altın karşılığı</div>}
+            </td>
             <td>
               {startValues.goldValue.toFixed(1)} (₺: {data.find(d => d.Date === startDate)?.GoldPerGramTRY})
             </td>
@@ -126,7 +135,9 @@ function ComparisonTable({
             </td>
           </tr>
           <tr>
-            <td>👨🏼‍🔧</td>
+            <td className="icon-cell" onClick={() => setTooltip(tooltip==='wage'?null:'wage')}>👨🏼‍🔧
+              {tooltip==='wage' && <div className="icon-tooltip">Asgari ücret oranı</div>}
+            </td>
             <td>
               {startValues.minWageRatio.toFixed(2)}× (₺: {data.find(d => d.Date === startDate)?.minWageNetTRY})
             </td>
@@ -135,7 +146,10 @@ function ComparisonTable({
             </td>
           </tr>
           <tr>
-            <td>{baseCurrency === "TRY" ? "⊴$⊵" : "⊴₺⊵"}</td>
+            <td className="icon-cell" onClick={() => setTooltip(tooltip==='norm'?null:'norm')}>
+              {baseCurrency === "TRY" ? "⊴$⊵" : "⊴₺⊵"}
+              {tooltip==='norm' && <div className="icon-tooltip">Normalleştirilmiş değer</div>}
+            </td>
             <td>{startValues.normalizedValue.toFixed(2)}</td>
             <td>{endValues.normalizedValue.toFixed(2)}</td>
           </tr>

--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -29,6 +29,28 @@ const Graph = ({ data, startDate, endDate }) => {
   if (filtered.length === 0) return null;
 
   const first = filtered[0];
+  const tooltipValue = (item, label) => {
+    switch (label) {
+      case "Enflasyon Endeksi":
+        return getInflation(item);
+      case "Altın Fiyatı (Gram/TRY)":
+        return item.GoldPerGramTRY;
+      case "Altın Fiyatı (Gram/USD)":
+        return item.GoldPerGramTRY / item.USDTRY;
+      case "USD/TRY":
+        return item.USDTRY;
+      case "EUR/TRY":
+        return item.EURTRY;
+      case "Asgari Ücret (TRY)":
+        return item.minWageNetTRY;
+      case "Asgari Ücret (USD)":
+        return item.minWageNetUSD;
+      case "Normalize TRY":
+        return item.USDTRY_TRY_NORM;
+      default:
+        return 0;
+    }
+  };
 
   const getInflation = (item) => item.InflationIndex ?? item.TRYInflationIndex;
 
@@ -108,6 +130,18 @@ const Graph = ({ data, startDate, endDate }) => {
     scales: {
       y: {
         ticks: { callback: (val) => val.toFixed(2) },
+      },
+    },
+    plugins: {
+      tooltip: {
+        callbacks: {
+          label: (ctx) => {
+            const ratio = ctx.parsed.y;
+            const item = filtered[ctx.dataIndex];
+            const actual = tooltipValue(item, ctx.dataset.label);
+            return `${ctx.dataset.label}: ${ratio.toFixed(2)}x (${actual.toFixed(2)})`;
+          },
+        },
       },
     },
   };

--- a/src/components/OrientationHint.js
+++ b/src/components/OrientationHint.js
@@ -1,0 +1,20 @@
+import React, { useEffect, useState } from "react";
+
+const OrientationHint = () => {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setVisible(false), 5000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div className="orientation-hint" onClick={() => setVisible(false)}>
+      Uygulamayı verimli kullanmak için telefonu yan çeviriniz
+    </div>
+  );
+};
+
+export default OrientationHint;


### PR DESCRIPTION
## Summary
- support default dark mode on startup
- stack date controls vertically
- show orientation hint for mobile users
- add click-based tooltips on icons
- show actual values in chart tooltips
- tweak responsive font sizes
- bump version to 2.2.8

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687514a9bc208327bc9e69939ae34e8d