### PR TITLE
Fix icon tooltips, dark mode table style, and chart color

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -62,9 +62,14 @@ body.dark-mode {
   color: var(--text-dark);
 }
 
-body.dark-mode .filters,
-body.dark-mode .comparison-table {
+body.dark-mode .filters {
   background-color: var(--surface-dark);
+  color: var(--text-dark);
+  border-color: #444444;
+}
+
+body.dark-mode .comparison-table {
+  background-color: #333333;
   color: var(--text-dark);
   border-color: #444444;
 }
@@ -162,7 +167,7 @@ h1 {
   border-spacing: 0;
   background: #ffffff;
   border-radius: 12px;
-  overflow: hidden;
+  overflow: visible;
   box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
 }
 

--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -24,7 +24,7 @@ const Graph = ({ data, startDate, endDate }) => {
     usdtry: "rgba(255,159,64,1)",
     eurtry: "rgba(153,102,255,1)",
     wageTRY: "rgba(255,205,86,1)",
-    wageUSD: "rgba(201,203,207,1)",
+    wageUSD: "rgba(0, 200, 83, 1)",
     normTRY: "rgba(75,192,192,0.5)",
   };
 
@@ -120,7 +120,7 @@ const Graph = ({ data, startDate, endDate }) => {
       {
         label: "Asgari Ücret (USD)",
         data: filtered.map((item) => item.minWageNetUSD / first.minWageNetUSD),
-        borderColor: "rgba(201,203,207,1)",
+        borderColor: "rgba(0, 200, 83, 1)",
         fill: false,
         hidden: !visible.wageUSD,
       },


### PR DESCRIPTION
## Summary
- ensure tooltips show by allowing overflow on `.comparison-table`
- set dark mode table background to a subtle grey
- update Asgari Ücret (USD) chart color to green

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6875237b29ac8327be6f46fcce0fc720