### PR TITLE
Improve orientation hint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purchase-power-3",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.14.1",

--- a/src/App.css
+++ b/src/App.css
@@ -334,32 +334,39 @@ button:active {
   }
 }
 
-.orientation-hint {
+
+.orientation-hint-overlay {
   position: fixed;
   inset: 0;
   display: flex;
   justify-content: center;
   align-items: center;
-  background: rgba(0, 0, 0, 0.95);
-  color: #fff;
-  font-size: 1.5rem;
-  text-align: center;
+  background: rgba(0, 0, 0, 0.2);
   z-index: 1050;
-  animation: fadeOutHint 6s linear forwards;
+  animation: fadeOutHint 5s linear forwards;
+}
+
+.orientation-hint {
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  font-size: 1.3rem;
+  text-align: center;
 }
 
 @media (min-width: 768px) {
-  .orientation-hint {
+  .orientation-hint-overlay {
     display: none;
   }
 }
 
 @keyframes fadeOutHint {
   from {
-    opacity: 0.95;
+    opacity: 1;
   }
   to {
-    opacity: 0.2;
+    opacity: 0;
   }
 }
 

--- a/src/components/OrientationHint.js
+++ b/src/components/OrientationHint.js
@@ -4,15 +4,17 @@ const OrientationHint = () => {
   const [visible, setVisible] = useState(true);
 
   useEffect(() => {
-    const timer = setTimeout(() => setVisible(false), 6000);
+    const timer = setTimeout(() => setVisible(false), 5000);
     return () => clearTimeout(timer);
   }, []);
 
   if (!visible) return null;
 
   return (
-    <div className="orientation-hint" onClick={() => setVisible(false)}>
-      Uygulamayı verimli kullanmak için cihazı yan çeviriniz 🔄
+    <div className="orientation-hint-overlay" onClick={() => setVisible(false)}>
+      <div className="orientation-hint">
+        Uygulamayı verimli kullanmak için cihazı yan çeviriniz 🔄
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add overlay container for orientation hint
- fade hint out after 5s and lighten background
- bump version to 2.2.11

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_687526c93570832793939ca3cc766b07