### PR TITLE
Add click handling for tooltips

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purchase-power-3",
-  "version": "2.2.12",
+  "version": "2.2.13",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.14.1",

--- a/src/components/ComparisonTable.js
+++ b/src/components/ComparisonTable.js
@@ -97,6 +97,7 @@ function ComparisonTable({
           <tr>
             <td
               className="icon-cell"
+              onClick={() => setTooltip(tooltip === 'try' ? null : 'try')}
               onMouseEnter={() => setTooltip('try')}
               onMouseLeave={() => setTooltip(null)}
               onTouchStart={() => setTooltip('try')}
@@ -113,6 +114,7 @@ function ComparisonTable({
           <tr>
             <td
               className="icon-cell"
+              onClick={() => setTooltip(tooltip === 'usd' ? null : 'usd')}
               onMouseEnter={() => setTooltip('usd')}
               onMouseLeave={() => setTooltip(null)}
               onTouchStart={() => setTooltip('usd')}
@@ -133,6 +135,7 @@ function ComparisonTable({
           <tr>
             <td
               className="icon-cell"
+              onClick={() => setTooltip(tooltip === 'eur' ? null : 'eur')}
               onMouseEnter={() => setTooltip('eur')}
               onMouseLeave={() => setTooltip(null)}
               onTouchStart={() => setTooltip('eur')}
@@ -153,6 +156,7 @@ function ComparisonTable({
           <tr>
             <td
               className="icon-cell"
+              onClick={() => setTooltip(tooltip === 'gold' ? null : 'gold')}
               onMouseEnter={() => setTooltip('gold')}
               onMouseLeave={() => setTooltip(null)}
               onTouchStart={() => setTooltip('gold')}
@@ -173,6 +177,7 @@ function ComparisonTable({
           <tr>
             <td
               className="icon-cell"
+              onClick={() => setTooltip(tooltip === 'wage' ? null : 'wage')}
               onMouseEnter={() => setTooltip('wage')}
               onMouseLeave={() => setTooltip(null)}
               onTouchStart={() => setTooltip('wage')}
@@ -193,6 +198,7 @@ function ComparisonTable({
           <tr>
             <td
               className="icon-cell"
+              onClick={() => setTooltip(tooltip === 'norm' ? null : 'norm')}
               onMouseEnter={() => setTooltip('norm')}
               onMouseLeave={() => setTooltip(null)}
               onTouchStart={() => setTooltip('norm')}


### PR DESCRIPTION
## Summary
- show tooltips when clicking icons
- bump version to 2.2.13

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_687530e1c2a88327a67bab0e3d8331ed