### PR TITLE
Implement super mode and UI tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purchase-power-3",
-  "version": "2.2.13",
+  "version": "2.2.14",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.14.1",

--- a/src/App.css
+++ b/src/App.css
@@ -30,7 +30,7 @@ body {
 
 @media (max-width: 768px) {
   body {
-    font-size: 0.8rem;
+    font-size: 0.75rem;
   }
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -13,9 +13,20 @@ function App() {
   const [startDate, setStartDate] = useState("2020-01");
   const [endDate, setEndDate] = useState("2025-07");
   const [amount, setAmount] = useState(100); // Başlangıç miktarı
+  const [superMode, setSuperMode] = useState(false);
+  const [logoClicks, setLogoClicks] = useState(0);
   const [darkMode, setDarkMode] = useState(() =>
     window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
   );
+
+  const handleLogoClick = () => {
+    if (superMode) return;
+    const next = logoClicks + 1;
+    if (next >= 5) {
+      setSuperMode(true);
+    }
+    setLogoClicks(next);
+  };
 
   useEffect(() => {
     const loadData = async () => {
@@ -48,7 +59,12 @@ function App() {
       <OrientationHint />
       <header className="d-flex justify-content-between align-items-center mb-4 fade-in">
         <div className="d-flex align-items-center gap-2">
-          <img src={logoUrl} alt="Alim Gucu" style={{ height: "60px" }} />
+          <img
+            src={logoUrl}
+            alt="Alim Gucu"
+            style={{ height: "60px", cursor: "pointer" }}
+            onClick={handleLogoClick}
+          />
           <h1 className="mb-0">Para Değeri Karşılaştırma</h1>
         </div>
         <button
@@ -69,6 +85,7 @@ function App() {
         setAmount={setAmount}
         setStartDate={setStartDate}
         setEndDate={setEndDate}
+        superMode={superMode}
       />
       <Graph data={data} startDate={startDate} endDate={endDate} />
       <footer className="text-center mt-4">

--- a/src/components/ComparisonTable.js
+++ b/src/components/ComparisonTable.js
@@ -19,10 +19,22 @@ function ComparisonTable({
   setStartDate,
   setEndDate,
   setAmount,
+  superMode,
 }) {
   const incStartDate = (diff) => setStartDate(adjustMonth(startDate, diff));
   const incEndDate = (diff) => setEndDate(adjustMonth(endDate, diff));
   const [tooltip, setTooltip] = useState(null);
+
+  const handleIconClick = (key) => {
+    if (tooltip === key) {
+      setTooltip(null);
+    } else {
+      setTooltip(key);
+      setTimeout(() => {
+        setTooltip((current) => (current === key ? null : current));
+      }, 1500);
+    }
+  };
   const { startValues, endValues } = calculateValues(
     data,
     baseCurrency,
@@ -62,7 +74,9 @@ function ComparisonTable({
             <th className="align-middle">
               <label htmlFor="startDate">Başlangıç</label>
               <div className="d-flex flex-column align-items-center gap-1">
-                <button type="button" onClick={() => incStartDate(1)}>+</button>
+                {superMode && (
+                  <button type="button" onClick={() => incStartDate(1)}>+</button>
+                )}
                 <input
                   type="month"
                   id="startDate"
@@ -72,13 +86,17 @@ function ComparisonTable({
                   max="2025-07"
                   step="1"
                 />
-                <button type="button" onClick={() => incStartDate(-1)}>-</button>
+                {superMode && (
+                  <button type="button" onClick={() => incStartDate(-1)}>-</button>
+                )}
               </div>
             </th>
             <th className="align-middle">
               <label htmlFor="endDate">Bitiş</label>
               <div className="d-flex flex-column align-items-center gap-1">
-                <button type="button" onClick={() => incEndDate(1)}>+</button>
+                {superMode && (
+                  <button type="button" onClick={() => incEndDate(1)}>+</button>
+                )}
                 <input
                   type="month"
                   id="endDate"
@@ -88,7 +106,9 @@ function ComparisonTable({
                   max="2025-07"
                   step="1"
                 />
-                <button type="button" onClick={() => incEndDate(-1)}>-</button>
+                {superMode && (
+                  <button type="button" onClick={() => incEndDate(-1)}>-</button>
+                )}
               </div>
             </th>
           </tr>
@@ -97,11 +117,10 @@ function ComparisonTable({
           <tr>
             <td
               className="icon-cell"
-              onClick={() => setTooltip(tooltip === 'try' ? null : 'try')}
+              onClick={() => handleIconClick('try')}
               onMouseEnter={() => setTooltip('try')}
               onMouseLeave={() => setTooltip(null)}
-              onTouchStart={() => setTooltip('try')}
-              onTouchEnd={() => setTooltip(null)}
+              onTouchStart={() => handleIconClick('try')}
             >
               ₺
               {tooltip==='try' && (
@@ -114,11 +133,10 @@ function ComparisonTable({
           <tr>
             <td
               className="icon-cell"
-              onClick={() => setTooltip(tooltip === 'usd' ? null : 'usd')}
+              onClick={() => handleIconClick('usd')}
               onMouseEnter={() => setTooltip('usd')}
               onMouseLeave={() => setTooltip(null)}
-              onTouchStart={() => setTooltip('usd')}
-              onTouchEnd={() => setTooltip(null)}
+              onTouchStart={() => handleIconClick('usd')}
             >
               $
               {tooltip==='usd' && (
@@ -135,11 +153,10 @@ function ComparisonTable({
           <tr>
             <td
               className="icon-cell"
-              onClick={() => setTooltip(tooltip === 'eur' ? null : 'eur')}
+              onClick={() => handleIconClick('eur')}
               onMouseEnter={() => setTooltip('eur')}
               onMouseLeave={() => setTooltip(null)}
-              onTouchStart={() => setTooltip('eur')}
-              onTouchEnd={() => setTooltip(null)}
+              onTouchStart={() => handleIconClick('eur')}
             >
               €
               {tooltip==='eur' && (
@@ -156,11 +173,10 @@ function ComparisonTable({
           <tr>
             <td
               className="icon-cell"
-              onClick={() => setTooltip(tooltip === 'gold' ? null : 'gold')}
+              onClick={() => handleIconClick('gold')}
               onMouseEnter={() => setTooltip('gold')}
               onMouseLeave={() => setTooltip(null)}
-              onTouchStart={() => setTooltip('gold')}
-              onTouchEnd={() => setTooltip(null)}
+              onTouchStart={() => handleIconClick('gold')}
             >
               🏅
               {tooltip==='gold' && (
@@ -177,11 +193,10 @@ function ComparisonTable({
           <tr>
             <td
               className="icon-cell"
-              onClick={() => setTooltip(tooltip === 'wage' ? null : 'wage')}
+              onClick={() => handleIconClick('wage')}
               onMouseEnter={() => setTooltip('wage')}
               onMouseLeave={() => setTooltip(null)}
-              onTouchStart={() => setTooltip('wage')}
-              onTouchEnd={() => setTooltip(null)}
+              onTouchStart={() => handleIconClick('wage')}
             >
               👨🏼‍🔧
               {tooltip==='wage' && (
@@ -198,11 +213,10 @@ function ComparisonTable({
           <tr>
             <td
               className="icon-cell"
-              onClick={() => setTooltip(tooltip === 'norm' ? null : 'norm')}
+              onClick={() => handleIconClick('norm')}
               onMouseEnter={() => setTooltip('norm')}
               onMouseLeave={() => setTooltip(null)}
-              onTouchStart={() => setTooltip('norm')}
-              onTouchEnd={() => setTooltip(null)}
+              onTouchStart={() => handleIconClick('norm')}
             >
               {baseCurrency === "TRY" ? "⊴$⊵" : "⊴₺⊵"}
               {tooltip==='norm' && (


### PR DESCRIPTION
## Summary
- add a hidden **super mode** activated by clicking the logo five times
- hide date adjustment buttons until super mode is activated
- improve icon tooltip handling on mobile
- reduce mobile font sizes slightly
- bump version to 2.2.14

## Testing
- `yarn test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687534c734bc832794bd0d7292407803