### PR TITLE
Fix tooltip interaction and tweak form layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purchase-power-3",
-  "version": "2.2.14",
+  "version": "2.2.15",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.14.1",

--- a/src/App.css
+++ b/src/App.css
@@ -237,8 +237,8 @@ select {
 th > label,
 th > input,
 th > select {
-  display: block;
-  margin: 0 auto;
+  display: inline-block;
+  margin: 0 4px;
   text-align: center;
   max-width: 200px;
 }

--- a/src/components/ComparisonTable.js
+++ b/src/components/ComparisonTable.js
@@ -26,14 +26,7 @@ function ComparisonTable({
   const [tooltip, setTooltip] = useState(null);
 
   const handleIconClick = (key) => {
-    if (tooltip === key) {
-      setTooltip(null);
-    } else {
-      setTooltip(key);
-      setTimeout(() => {
-        setTooltip((current) => (current === key ? null : current));
-      }, 1500);
-    }
+    setTooltip((current) => (current === key ? null : key));
   };
   const { startValues, endValues } = calculateValues(
     data,
@@ -52,25 +45,30 @@ function ComparisonTable({
       <table className="comparison-table table table-bordered fade-in">
         <thead>
           <tr>
-            <th>
-              <label htmlFor="amount">MİKTAR:</label>
-              <input
-                type="number"
-                id="amount"
-                value={amount}
-                onChange={(e) => setAmount(Number(e.target.value))}
-                min="1"
-              />
-              <label htmlFor="baseCurrency">KUR:</label>
-              <select
-                id="baseCurrency"
-                value={baseCurrency}
-                onChange={(e) => setBaseCurrency(e.target.value)}
-              >
-                <option value="TRY">TRY</option>
-                <option value="USD">USD</option>
-              </select>
+            <th colSpan="3">
+              <div className="d-flex justify-content-center flex-wrap gap-2">
+                <label htmlFor="amount" className="mb-0">MİKTAR:</label>
+                <input
+                  type="number"
+                  id="amount"
+                  value={amount}
+                  onChange={(e) => setAmount(Number(e.target.value))}
+                  min="1"
+                />
+                <label htmlFor="baseCurrency" className="mb-0">KUR:</label>
+                <select
+                  id="baseCurrency"
+                  value={baseCurrency}
+                  onChange={(e) => setBaseCurrency(e.target.value)}
+                >
+                  <option value="TRY">TRY</option>
+                  <option value="USD">USD</option>
+                </select>
+              </div>
             </th>
+          </tr>
+          <tr>
+            <th></th>
             <th className="align-middle">
               <label htmlFor="startDate">Başlangıç</label>
               <div className="d-flex flex-column align-items-center gap-1">


### PR DESCRIPTION
## Summary
- enable toggling tooltips on icon click
- arrange amount/currency at top and dates below in header
- adjust input styles for inline display
- bump version to 2.2.15

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6875382b403883278c5fc7170aaad84f