### PR TITLE
Improve mobile styles and dark theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purchase-power-3",
-  "version": "2.2.16",
+  "version": "2.2.17",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.14.1",

--- a/src/App.css
+++ b/src/App.css
@@ -73,6 +73,10 @@ body.dark-mode .comparison-table {
   color: var(--text-dark);
   border-color: #444444;
 }
+body.dark-mode .comparison-table th {
+  background-color: #555555;
+  color: var(--text-dark);
+}
 
 body.dark-mode .filters input,
 body.dark-mode .filters select,
@@ -314,10 +318,14 @@ button:active {
     padding: 10px;
   }
 
-  .filters,
-  .filter-bar {
+  .filters {
     flex-direction: column;
     align-items: stretch;
+    gap: 15px;
+  }
+
+  .filter-bar {
+    flex-wrap: wrap;
     gap: 15px;
   }
 

--- a/src/components/ComparisonTable.js
+++ b/src/components/ComparisonTable.js
@@ -56,6 +56,7 @@ function ComparisonTable({
         incEndDate={incEndDate}
         superMode={superMode}
       />
+      <div className="table-responsive">
       <table className="comparison-table table table-hover table-bordered text-center fade-in">
         <thead className="table-primary">
           <tr>
@@ -180,6 +181,7 @@ function ComparisonTable({
         </tbody>
 
       </table>
+      </div>
     </>
   );
 }

--- a/src/components/FilterControls.js
+++ b/src/components/FilterControls.js
@@ -14,8 +14,8 @@ function FilterControls({
   superMode,
 }) {
   return (
-    <form className="row g-3 bg-light p-3 rounded shadow-sm align-items-end filter-bar">
-      <div className="col-6 col-md-2">
+    <form className="row g-3 p-3 rounded shadow-sm align-items-end filter-bar">
+      <div className="col-12 col-md-2">
         <label htmlFor="amount" className="form-label">Miktar</label>
         <input
           type="number"
@@ -26,7 +26,7 @@ function FilterControls({
           onChange={(e) => setAmount(Number(e.target.value))}
         />
       </div>
-      <div className="col-6 col-md-2">
+      <div className="col-12 col-md-2">
         <label htmlFor="baseCurrency" className="form-label">Kur</label>
         <select
           id="baseCurrency"


### PR DESCRIPTION
## Summary
- better mobile stacking for filters and table
- tweak dark mode table colors
- add responsive table wrapper
- bump version to 2.2.17

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68754390787483278fe8f8d8fb935bda