### PR TITLE
Improve mobile layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purchase-power-3",
-  "version": "2.2.17",
+  "version": "2.2.18",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.14.1",

--- a/src/App.css
+++ b/src/App.css
@@ -417,6 +417,8 @@ button:active {
   border-radius: 4px;
   font-size: 0.75rem;
   white-space: nowrap;
+  max-width: 90vw;
+  text-align: center;
   z-index: 1100;
 }
 

--- a/src/components/FilterControls.js
+++ b/src/components/FilterControls.js
@@ -15,7 +15,7 @@ function FilterControls({
 }) {
   return (
     <form className="row g-3 p-3 rounded shadow-sm align-items-end filter-bar">
-      <div className="col-12 col-md-2">
+      <div className="col-6 col-md-2">
         <label htmlFor="amount" className="form-label">Miktar</label>
         <input
           type="number"
@@ -26,7 +26,7 @@ function FilterControls({
           onChange={(e) => setAmount(Number(e.target.value))}
         />
       </div>
-      <div className="col-12 col-md-2">
+      <div className="col-6 col-md-2">
         <label htmlFor="baseCurrency" className="form-label">Kur</label>
         <select
           id="baseCurrency"
@@ -38,7 +38,7 @@ function FilterControls({
           <option value="USD">USD</option>
         </select>
       </div>
-      <div className="col-12 col-md-4">
+      <div className="col-6 col-md-4">
         <label htmlFor="startDate" className="form-label">Başlangıç</label>
         <div className="input-group">
           {superMode && (
@@ -71,7 +71,7 @@ function FilterControls({
           )}
         </div>
       </div>
-      <div className="col-12 col-md-4">
+      <div className="col-6 col-md-4">
         <label htmlFor="endDate" className="form-label">Bitiş</label>
         <div className="input-group">
           {superMode && (


### PR DESCRIPTION
## Summary
- keep tooltip within the viewport
- align amount/currency, start and end date inputs side by side on small screens
- bump version number

## Testing
- `yarn install`
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_687547a44c9c83278ccb870f1298fb65