### PR TITLE
Fix mobile form layout and tooltip size

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -259,7 +259,7 @@ select {
   border: 1px solid #e0e0e0;
   border-radius: 6px;
   font-size: 0.95rem;
-  width: 90%;
+  width: 100%;
   box-sizing: border-box;
   background: #f9f9f9;
   color: #222222;
@@ -422,17 +422,17 @@ button:active {
 
 .icon-tooltip {
   position: absolute;
-  bottom: -1.8em;
+  bottom: -2.2em;
   left: 50%;
   transform: translateX(-50%);
   background: rgba(0, 0, 0, 0.75);
   color: #fff;
-  padding: 2px 6px;
+  padding: 4px 8px;
   border-radius: 4px;
-  font-size: 0.75rem;
+  font-size: 0.85rem;
   white-space: normal;
   word-break: break-word;
-  max-width: 90vw;
+  max-width: 95vw;
   text-align: center;
   z-index: 1100;
 }

--- a/src/components/FilterControls.js
+++ b/src/components/FilterControls.js
@@ -15,7 +15,7 @@ function FilterControls({
 }) {
   return (
     <form className="row g-3 p-3 rounded shadow-sm align-items-end filter-bar">
-      <div className="col-6 col-md-2">
+      <div className="col-12 col-sm-6 col-md-2">
         <label htmlFor="amount" className="form-label">Miktar</label>
         <input
           type="number"
@@ -26,7 +26,7 @@ function FilterControls({
           onChange={(e) => setAmount(Number(e.target.value))}
         />
       </div>
-      <div className="col-6 col-md-2">
+      <div className="col-12 col-sm-6 col-md-2">
         <label htmlFor="baseCurrency" className="form-label">Kur</label>
         <select
           id="baseCurrency"
@@ -38,7 +38,7 @@ function FilterControls({
           <option value="USD">USD</option>
         </select>
       </div>
-      <div className="col-6 col-md-4">
+      <div className="col-12 col-sm-6 col-md-4">
         <label htmlFor="startDate" className="form-label">Başlangıç</label>
         <div className="input-group">
           {superMode && (
@@ -71,7 +71,7 @@ function FilterControls({
           )}
         </div>
       </div>
-      <div className="col-6 col-md-4">
+      <div className="col-12 col-sm-6 col-md-4">
         <label htmlFor="endDate" className="form-label">Bitiş</label>
         <div className="input-group">
           {superMode && (


### PR DESCRIPTION
## Summary
- improve mobile column sizes in `FilterControls`
- make form inputs use full width
- enlarge tooltip styling for comparison table

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6875525ae88483279b344609f6105ecc