### PR TITLE
Improve mobile filters layout and tooltip

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -430,8 +430,8 @@ button:active {
   padding: 4px 8px;
   border-radius: 4px;
   font-size: 0.85rem;
-  white-space: normal;
-  word-break: break-word;
+  white-space: nowrap;
+  width: max-content;
   max-width: 95vw;
   text-align: center;
   z-index: 1100;
@@ -439,6 +439,8 @@ button:active {
 
 @media (max-width: 768px) {
   .icon-tooltip {
+    white-space: normal;
+    width: auto;
     max-width: calc(100vw - 20px);
   }
 }

--- a/src/components/FilterControls.js
+++ b/src/components/FilterControls.js
@@ -15,7 +15,7 @@ function FilterControls({
 }) {
   return (
     <form className="row g-3 p-3 rounded shadow-sm align-items-end filter-bar">
-      <div className="col-12 col-sm-6 col-md-2">
+      <div className="col-6 col-md-2">
         <label htmlFor="amount" className="form-label">Miktar</label>
         <input
           type="number"
@@ -26,7 +26,7 @@ function FilterControls({
           onChange={(e) => setAmount(Number(e.target.value))}
         />
       </div>
-      <div className="col-12 col-sm-6 col-md-2">
+      <div className="col-6 col-md-2">
         <label htmlFor="baseCurrency" className="form-label">Kur</label>
         <select
           id="baseCurrency"
@@ -38,7 +38,7 @@ function FilterControls({
           <option value="USD">USD</option>
         </select>
       </div>
-      <div className="col-12 col-sm-6 col-md-4">
+      <div className="col-6 col-md-4">
         <label htmlFor="startDate" className="form-label">Başlangıç</label>
         <div className="input-group">
           {superMode && (
@@ -71,7 +71,7 @@ function FilterControls({
           )}
         </div>
       </div>
-      <div className="col-12 col-sm-6 col-md-4">
+      <div className="col-6 col-md-4">
         <label htmlFor="endDate" className="form-label">Bitiş</label>
         <div className="input-group">
           {superMode && (


### PR DESCRIPTION
## Summary
- update grid classes in `FilterControls` for 2x2 layout on small screens
- allow tooltips to expand horizontally and wrap on small screens

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6875570dde108327b9292d12081e969b