### PR TITLE
Improve mobile filter layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -147,6 +147,9 @@ h1 {
 
 /* Yeni filtre tasarımı */
 .filter-bar {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
   max-width: 1200px;
   margin: 20px auto;
   background: #ffffff;
@@ -157,6 +160,12 @@ h1 {
 
 body.dark-mode .filter-bar {
   background: var(--surface-dark);
+}
+
+@media (min-width: 768px) {
+  .filter-bar {
+    grid-template-columns: repeat(4, 1fr);
+  }
 }
 
 .filters label {
@@ -336,8 +345,8 @@ button:active {
   }
 
   .filter-bar {
-    flex-wrap: wrap;
-    gap: 5px;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.5rem;
     margin: 0;
     border-radius: 0;
     box-shadow: none;

--- a/src/components/FilterControls.js
+++ b/src/components/FilterControls.js
@@ -14,8 +14,8 @@ function FilterControls({
   superMode,
 }) {
   return (
-    <form className="row row-cols-2 g-3 p-3 rounded shadow-sm align-items-end filter-bar">
-      <div className="col-md-2">
+    <form className="filter-bar p-3 rounded shadow-sm">
+      <div className="filter-item">
         <label htmlFor="amount" className="form-label">Miktar</label>
         <input
           type="number"
@@ -26,7 +26,7 @@ function FilterControls({
           onChange={(e) => setAmount(Number(e.target.value))}
         />
       </div>
-      <div className="col-md-2">
+      <div className="filter-item">
         <label htmlFor="baseCurrency" className="form-label">Kur</label>
         <select
           id="baseCurrency"
@@ -38,7 +38,7 @@ function FilterControls({
           <option value="USD">USD</option>
         </select>
       </div>
-      <div className="col-md-4">
+      <div className="filter-item">
         <label htmlFor="startDate" className="form-label">Başlangıç</label>
         <div className="input-group">
           {superMode && (
@@ -71,7 +71,7 @@ function FilterControls({
           )}
         </div>
       </div>
-      <div className="col-md-4">
+      <div className="filter-item">
         <label htmlFor="endDate" className="form-label">Bitiş</label>
         <div className="input-group">
           {superMode && (


### PR DESCRIPTION
## Summary
- redesign FilterControls layout using CSS grid
- adjust filter bar styles for mobile

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68755df46e548327bdf8b22fb09fdb7b